### PR TITLE
fix forgotten dereferenced datap pointer.

### DIFF
--- a/datatype.go
+++ b/datatype.go
@@ -155,7 +155,7 @@ func unpackDataValue(dvalue *C.DataValue, engine *Engine) interface{} {
 	case C.DTGoAddr:
 		// ObjectByName also does this fold conversion, to have access
 		// to the cvalue. Perhaps the fold should be returned.
-		fold := ensureEngine(engine.addr, C.GoRef(uintptr(datap)))
+		fold := ensureEngine(engine.addr, C.GoRef(uintptr(*(*unsafe.Pointer)(datap))))
 		return fold.gvalue
 	case C.DTInvalid:
 		return nil

--- a/examples/govalue/README.md
+++ b/examples/govalue/README.md
@@ -1,0 +1,38 @@
+# Reproducer for go1.6 port problem
+
+SjB's go 1.6 port worked very well for me for pretty much all of my programs, but
+I did discover one corner case that causes problems. The TL;DR is that passing a
+go type to qml and back to go does not work.
+
+## What I expect:
+
+Basically the old behaviour. After cloning this repo, try this:
+
+```
+GODEBUG=cgocheck=0 go run main.go
+```
+
+You should see it print, "Successfully called UseGoType()" and display a white rectangle.
+
+## It doesn't quite work so well with the fix
+
+If we use the 1.6 port (I have copied commit 0309d2df1d6572e107b2bd0712da5b517c4a49be here
+for your convenience) then it doesn't work quite like it used to:
+
+```
+mv vendor_cjb vendor
+go run main.go
+```
+
+You should see something like:
+
+```
+panic: cannot find fold go reference
+
+goroutine 1 [running, locked to thread]:
+panic(0x5716e0, 0xc820090070)
+	/usr/local/go/src/runtime/panic.go:464 +0x3e6
+.../vendor/gopkg.in/qml%2ev1.getFoldFromGoRef(0x7ffc3a3bc044, 0x8aec00)
+.../vendor/gopkg.in/qml.v1/bridge.go:230 +0x9e
+... cut ...
+```

--- a/examples/govalue/main.go
+++ b/examples/govalue/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"gopkg.in/qml.v1"
+)
+
+func main() {
+	err := qml.Run(run)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type GoStruct struct {
+}
+
+func (gs *GoStruct) ReturnGoType() *GoStruct {
+	return gs
+}
+func (gs *GoStruct) UseGoType(v *GoStruct) {
+	fmt.Println("Successfully called UseGoType()")
+}
+
+func run() error {
+	engine := qml.NewEngine()
+	context := engine.Context()
+	context.SetVar("gostruct", &GoStruct{})
+	component, err := engine.LoadFile("main.qml")
+	if err != nil {
+		return err
+	}
+	win := component.CreateWindow(nil)
+	win.Show()
+	win.Wait()
+	return nil
+}

--- a/examples/govalue/main.qml
+++ b/examples/govalue/main.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.0
+Rectangle {
+  width:600
+  height:600
+  Component.onCompleted: {
+    var gt = gostruct.returnGoType()
+    gt.useGoType(gt)
+  }
+}


### PR DESCRIPTION
When unpacking a DataValue of a DTGoAddr type, we forgot to dereference the datap pointer
that contained the GoRef.

Thanks to immesys on github, for pointing out the bug.
